### PR TITLE
fix: Expose READ_SOURCE_AND_PACKAGES as environment variable

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -41,9 +41,13 @@ jobs:
 
       - name: Execute gradle build
         run: ./gradlew build
+        env:
+          GITHUB_PAT: ${{ secrets.READ_SOURCE_AND_PACKAGES }}
 
       - name: Run tests
         run: ./gradlew test
+        env:
+          GITHUB_PAT: ${{ secrets.READ_SOURCE_AND_PACKAGES }}
 
       - name: Publish data to sonarcloud
         if: inputs.sonarcloud_project_id

--- a/.github/workflows/gradle-publish.yaml
+++ b/.github/workflows/gradle-publish.yaml
@@ -41,6 +41,7 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ env.GITHUB_ACTOR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PAT: ${{ secrets.READ_SOURCE_AND_PACKAGES }}
 
       - name: Show the built version number in the job run summary
         run: echo "### Published artifact ${{ github.repository }} version ${{ inputs.publish_version }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Expose READ_SOURCE_AND_PACKAGES as environment variable
gradle publish needs to pull inn packages when it builds what will
be published. If it needs packages from GPR, the GITHUB_TOKEN is
not sufficient to read packages from other repositories.